### PR TITLE
feat(add request.from() feature): 

### DIFF
--- a/src/buchu.js
+++ b/src/buchu.js
@@ -3,5 +3,6 @@ module.exports = {
     Err: require('./results').Err,
     usecase: require('./usecase').usecase,
     step: require('./step').step,
-    ifElse: require('./ifElse').ifElse
+    ifElse: require('./ifElse').ifElse,
+    request: require('./request').request
 }

--- a/src/request.js
+++ b/src/request.js
@@ -1,23 +1,21 @@
-class Request {
-    from(requestInputObject, settings) {
-        const objectInstance = new requestInputObject()
-        const objectProperties =  Object.getOwnPropertyNames(objectInstance)
-        const requestResultObject = {}
-        const requestSchemaClone = { ...requestInputObject.prototype.meta.schema }
+const request = {
+    from: (entity, settings) => {
+        const instance = new entity()
+        const properties =  Object.getOwnPropertyNames(instance)
+        const result = {}
+        const schema = { ...entity.prototype.meta.schema }
 
-        objectProperties.forEach (property => {
+        properties.forEach (property => {
             if (settings && settings.ignore && settings.ignore.includes(property)) return
 
-            requestResultObject[property] = requestSchemaClone[property].type
+            result[property] = schema[property].type
         })
 
         if (settings && settings.ignoreIDs)
-            delete requestResultObject.id
+            delete result.id
 
-        return requestResultObject
+        return result
     }
 }
-
-const request = new Request()
 
 module.exports = { request }

--- a/src/request.js
+++ b/src/request.js
@@ -1,0 +1,23 @@
+class Request {
+    from(requestInputObject, settings) {
+        const objectInstance = new requestInputObject()
+        const objectProperties =  Object.getOwnPropertyNames(objectInstance)
+        const requestResultObject = {}
+        const requestSchemaClone = { ...requestInputObject.prototype.meta.schema }
+
+        objectProperties.forEach (property => {
+            if (settings && settings.ignore && settings.ignore.includes(property)) return
+
+            requestResultObject[property] = requestSchemaClone[property].type
+        })
+
+        if (settings && settings.ignoreIDs)
+            delete requestResultObject.id
+
+        return requestResultObject
+    }
+}
+
+const request = new Request()
+
+module.exports = { request }

--- a/test/request/request.js
+++ b/test/request/request.js
@@ -1,0 +1,119 @@
+const assert = require('assert')
+const { request } = require('../../src/request')
+const { entity, field, id }  = require('@herbsjs/gotu')
+
+const anEntity = entity('anEntiy',{
+    id: id(Number),
+    stringField: field(String)    
+})
+
+const anEntityWithEntityField = entity('anEntityWithEntityField',{
+    id: id(Number),
+    stringField: field(String),
+    entityField: field(anEntity)
+})
+
+describe.only('Request from', () => {
+    it('should extract class schema with whole structure', () => {
+        //given
+        const schemaExpected = {
+            stringField: String, 
+            id: Number
+        }
+
+        //when
+        const requestResult = request.from(anEntity)
+
+        //then
+        assert.deepEqual(requestResult, schemaExpected)        
+    }),
+
+    it('should extract class schema with with entity as a field', () => {
+        //given
+        const entityFieldType = field(anEntity).type
+        const schemaExpected = {
+            id: Number,
+            stringField: String, 
+            entityField: entityFieldType
+        }
+
+        //when
+        const requestResult = request.from(anEntityWithEntityField)
+
+        //then
+        assert.deepEqual(requestResult, schemaExpected)        
+    }),
+
+    it('should throw error when trying to transform an object without constructor', () => {
+        //given
+        const emptyObject = {}
+
+        //then
+        assert.throws(() => request.from(emptyObject), Error)
+    }),
+
+    it('should throw error when trying to transform class without schema', () => {
+        //given
+        class AClass {}
+
+        //then
+        assert.throws(() => request.from(AClass), Error)
+    })
+
+    it('should remove IDs from main schema when ignoreIDs is true on settings', () => {
+        //given
+        const schemaExpected = {
+            stringField: String
+        }
+
+        //when
+        const settings = { ignoreIDs : true }
+        const requestResult = request.from(anEntity, settings)
+
+        //then
+        assert.deepEqual(requestResult, schemaExpected)        
+    }),
+
+    it('should remove property from main schema when setted on ignore array', () => {
+        //given
+        const schemaExpected = {
+            id: Number
+        }
+
+        //when
+        const settings = { ignore: ['stringField'] }
+        const requestResult = request.from(anEntity, settings)
+
+        //then
+        assert.deepEqual(requestResult, schemaExpected)        
+    }),
+
+    it('should remove entity as property from main schema when setted on ignore array', () => {
+        //given
+        const schemaExpected = {
+            id: Number,
+            stringField: String
+        }
+
+        //when
+        const settings = { ignore: ['entityField'] }
+        const requestResult = request.from(anEntityWithEntityField, settings)
+
+        //then
+        assert.deepEqual(requestResult, schemaExpected)        
+    }),
+
+    it('should work with both settings ignoreIDs and ignore setted up', () => {
+        //given
+        const schemaExpected = {
+            stringField: String
+        }
+
+        //when
+        const settings = { ignoreIDs: true, ignore: ['entityField'] }
+        const requestResult = request.from(anEntityWithEntityField, settings)
+
+        //then
+        assert.deepEqual(requestResult, schemaExpected)        
+    })
+})

--- a/test/request/request.js
+++ b/test/request/request.js
@@ -13,7 +13,7 @@ const anEntityWithEntityField = entity('anEntityWithEntityField',{
     entityField: field(anEntity)
 })
 
-describe.only('Request from', () => {
+describe('Request from', () => {
     it('should extract class schema with whole structure', () => {
         //given
         const schemaExpected = {


### PR DESCRIPTION
add request.from() feature which receives an object and settings

request.from() receives two parameters: an object that must contain a schema and settings, in which
you can ignore IDs and specific fields

#53

Documentation will be added as soon as this PR is reviewed
